### PR TITLE
Add single song download via --song flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ ffmpeg
 
 Make sure that you installed ffmpeg and can run `ffmpeg` in your terminal.
 
+Download everything:
 ```python3 main.py``` or ```python main.py```
+
+Download a single song by name or CID:
+```python3 main.py --song "Alive"``` or ```python3 main.py --song 514530```
+
+The song will be saved into its album folder with full metadata, cover art, and lyrics (same as a full download).
 
 ### Video instructions:
 https://drive.google.com/file/d/1Kzcn3GazpE9MHtzlkgJB3L0DtvsHK88M/view?usp=sharing

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import requests
 from tqdm import tqdm
 import pylrc
 import json
+import argparse
 
 from PIL import Image
 from multiprocessing import Pool, Manager
@@ -208,9 +209,82 @@ def download_album( args):
     return
 
 
+def download_single_song(session, directory, song_query):
+    """Download a single song by name or CID, searching across all albums."""
+    albums = session.get('https://monster-siren.hypergryph.com/api/albums', headers={'Accept': 'application/json'}).json()['data']
+
+    for album in albums:
+        album_cid = album['cid']
+        album_artistes = album['artistes']
+        album_detail = session.get('https://monster-siren.hypergryph.com/api/album/' + album_cid + '/detail', headers={'Accept': 'application/json'}).json()['data']
+        album_name = album_detail['name']
+        album_coverUrl = album_detail['coverUrl']
+
+        for song_track_number, song in enumerate(album_detail['songs']):
+            if song['cid'] == song_query or song['name'].lower() == song_query.lower():
+                song_cid = song['cid']
+                song_name = song['name']
+                song_artists = song['artistes']
+
+                song_detail = session.get('https://monster-siren.hypergryph.com/api/song/' + song_cid, headers={'Accept': 'application/json'}).json()['data']
+                song_lyricUrl = song_detail['lyricUrl']
+                song_sourceUrl = song_detail['sourceUrl']
+
+                album_dir = directory + make_valid(album_name)
+                try:
+                    os.mkdir(directory)
+                except:
+                    pass
+                try:
+                    os.mkdir(album_dir)
+                except:
+                    pass
+
+                # Download album art (same as download_album)
+                with open(album_dir + '/cover.jpg', 'w+b') as f:
+                    f.write(session.get(album_coverUrl).content)
+                cover = Image.open(album_dir + '/cover.jpg')
+                cover.save(album_dir + '/cover.png')
+                os.remove(album_dir + '/cover.jpg')
+
+                # Download lyric
+                if song_lyricUrl is not None:
+                    songlyricpath = album_dir + '/' + make_valid(song_name) + '.lrc'
+                    with open(songlyricpath, 'w+b') as f:
+                        f.write(session.get(song_lyricUrl).content)
+                else:
+                    songlyricpath = None
+
+                # Download song and fill metadata
+                filename, filetype = download_song(session=session, directory=album_dir, name=song_name, url=song_sourceUrl)
+                fill_metadata(filename=filename,
+                              filetype=filetype,
+                              album=album_name,
+                              title=song_name,
+                              albumartist=album_artistes,
+                              artist=song_artists,
+                              tracknumber=song_track_number,
+                              albumcover=album_dir + '/cover.png',
+                              songlyricpath=songlyricpath)
+
+                print(f'Downloaded: {song_name} [{album_name}]')
+                return
+
+    print(f'Song not found: {song_query}')
+
+
 def main():
+    parser = argparse.ArgumentParser(description='Monster Siren downloader')
+    parser.add_argument('--song', metavar='NAME_OR_CID', help='Download a single song by name or CID')
+    args = parser.parse_args()
+
     directory = './MonsterSiren/'
     session = requests.Session()
+
+    if args.song:
+        download_single_song(session, directory, args.song)
+        return
+
     manager = Manager()
     queue = manager.Queue()
     mutex = manager.Lock()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pydub
 pathvalidate
 pylrc
 Pillow
+audioop-lts; python_version >= "3.13"
+argparse


### PR DESCRIPTION
Adds a --song CLI argument to download a single song without pulling every album.

Usage:
  python3 main.py --song "Alive"
  python3 main.py --song 514530

The song is saved into its album folder with full metadata, cover art, and lyrics, identical to a full download.

Changes:
- main.py: new --song argument and download_single_song() function
- README.md: updated Runs section with --song usage
- requirements.txt: added argparse